### PR TITLE
automatically obtain latest user_agent header

### DIFF
--- a/SlackPirate.py
+++ b/SlackPirate.py
@@ -779,7 +779,7 @@ if __name__ == '__main__':
     parser.add_argument('--no-file-download', dest='file_download', action='store_false',
                         help='disable downloading of files from the Workspace')
     parser.add_argument('--version', action='version',
-                        version='SlackPirate.py v0.10. Developed by Mikail Tunç (@emtunc) with contributions from '
+                        version='SlackPirate.py v0.11. Developed by Mikail Tunç (@emtunc) with contributions from '
                                 'the amazing community! https://github.com/emtunc/SlackPirate/graphs/contributors')
     """
     Even with "argument_default=None" in the constructor, all flags were False, so we explicitly set every flag to None

--- a/SlackPirate.py
+++ b/SlackPirate.py
@@ -12,7 +12,7 @@ import queue
 
 from typing import List
 from multiprocessing import Process, Queue
-from constants import getUserAgent
+from constants import get_user_agent
 
 
 #############
@@ -789,7 +789,7 @@ if __name__ == '__main__':
                         private_key_scan=None, link_scan=None, file_download=None, pinned_message_scan=None)
     args = parser.parse_args()
 
-    selected_agent = getUserAgent()
+    selected_agent = get_user_agent()
 
     if args.cookie is None and args.token is None:  # Must provide one or the other
         print(termcolor.colored("No arguments passed. Run SlackPirate.py --help ", "white", "on_red"))

--- a/constants.py
+++ b/constants.py
@@ -4,6 +4,7 @@ Contains function to select random user agent.
 """
 
 import random
+import requests
 
 user_agents = [
     "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:63.0) Gecko/20100101 Firefox/63.0",
@@ -29,5 +30,15 @@ user_agents = [
 ]
 
 
-def getUserAgent():
-    return random.choice(user_agents)
+def get_user_agent():
+    operating_systems = ['windows', 'osx']
+    browsers = ['chrome', 'firefox']
+    try:
+        user_agent = requests.get(
+            "https://api.user-agent.io/?browser=" + random.choice(browsers) + "&os=" + random.choice(operating_systems))
+        if user_agent.status_code == 200 and "Mozilla" in user_agent.text:
+            return user_agent.text
+        else:
+            return random.choice(user_agents)
+    except requests.exceptions.RequestException:
+        return random.choice(user_agents)


### PR DESCRIPTION
this PR will call an API that I created which will automatically pull the latest versions of user headers for osx/windows and chrome/firefox.
If the API is not available then we will fall back to the static user_agent list in constants.py