### PR TITLE
Automatically URL encode cookie if it's URL decoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .*/
 __pycache__
-SlackPirate/
+SlackPirate_*/

--- a/SlackPirate.py
+++ b/SlackPirate.py
@@ -9,6 +9,7 @@ import colorama
 import requests
 import termcolor
 import queue
+import urllib.parse
 
 from typing import List
 from multiprocessing import Process, Queue
@@ -163,6 +164,8 @@ def display_cookie_tokens(cookie, user_agent):
     """
 
     try:
+        if cookie['d'].endswith("="):
+            cookie['d'] = urllib.parse.quote(cookie['d'])
         r = requests.get("https://slackpirate-donotuse.slack.com", cookies=cookie)
         already_signed_in_match = re.findall(ALREADY_SIGNED_IN_TEAM_REGEX, str(r.content))
         if already_signed_in_match:


### PR DESCRIPTION
Firefox's dev tool returns the `d` cookie in a URL decoded format, which breaks the token retrieval with `--cookie`.

This fix checks if the cookie ends with a '=' (URL decoded) and then encodes the string.