### PR TITLE
Exclude slack permalinks from aws_keys_regex

### DIFF
--- a/SlackPirate.py
+++ b/SlackPirate.py
@@ -98,7 +98,8 @@ CREDENTIALS_REGEX = r"(?i)(" \
                     r"pwd\s*[`=:\"]*\s*[^\s]+|" \
                     r"passwd\s*[`=:\"]+\s*[^\s]+)"
 # https://regex101.com/r/IEq5nU/4
-AWS_KEYS_REGEX = r"((?<![A-Za-z0-9/+])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])|(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))"
+AWS_KEYS_REGEX = r"(?!com/archives/[A-Z0-9]{9}/p[0-9]{16})" \
+                 r"((?<![A-Za-z0-9/+])[A-Za-z0-9/+]{40}(?![A-Za-z0-9/+])|(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))"
 # https://regex101.com/r/SU43wh/1
 # Top-level domain capture group
 TLD_GROUP = r"(?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int" \

--- a/SlackPirate.py
+++ b/SlackPirate.py
@@ -97,7 +97,7 @@ CREDENTIALS_REGEX = r"(?i)(" \
                     r"password is\s*[`=:\"]*\s*[^\s]+|" \
                     r"pwd\s*[`=:\"]*\s*[^\s]+|" \
                     r"passwd\s*[`=:\"]+\s*[^\s]+)"
-# https://regex101.com/r/IEq5nU/4
+# https://regex101.com/r/IEq5nU/5
 AWS_KEYS_REGEX = r"(?!com/archives/[A-Z0-9]{9}/p[0-9]{16})" \
                  r"((?<![A-Za-z0-9/+])[A-Za-z0-9/+]{40}(?![A-Za-z0-9/+])|(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))"
 # https://regex101.com/r/SU43wh/1


### PR DESCRIPTION
The last 40 characters of Slack permalinks were false positively identified as AWS secret access keys.
This fixes that.
Thanks for the help, @annadorottya!